### PR TITLE
Support Node 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
 addons:
   apt:
     sources: ['ubuntu-toolchain-r-test']
-    packages: ['g++-6', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'lua5.1', 'liblua5.1-0-dev', 'libtbb-dev', 'libgdal-dev', 'libluabind-dev', 'libboost-all-dev']
+    packages: ['g++-6', 'gcc-6', 'build-essential', 'git', 'wget', 'cmake3', 'pkg-config', 'libbz2-dev', 'libstxxl-dev', 'libstxxl1', 'libxml2-dev', 'libzip-dev', 'libboost-all-dev', 'lua5.2', 'liblua5.2-dev', 'libtbb-dev']
 
-env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6'
+env: CPP=cpp-6 CC=gcc-6 CXX=g++-6
 
 branches:
   except:
@@ -22,6 +22,8 @@ branches:
 
 node_js:
   - "6"
+  - "7"
+  - "8"
 
 before_install: yarn global add greenkeeper-lockfile@1
 install: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ node_js:
   - "8"
 
 before_install: yarn global add greenkeeper-lockfile@1
-install: yarn
+install: travis_wait yarn
 
 before_script: greenkeeper-lockfile-update
 script: make test


### PR DESCRIPTION
Hopefully my last PR for now! Added Travis testing for Node 7 and 8.
* Node 7 support is important since [galton](https://github.com/urbica/galton) depends on it
* Node 8 was previously tested but was removed in f6b3a12a1de017ae903ad8032279b9012dbfd174

Node 4 and 6 install OSRM from prebuilt binaries. Other versions of Node are fine but OSRM needs to be built from source. We just need to ensure the necessary dependencies to build it are installed.