### PR TITLE
Omit unroutable points from isochrones

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const groupByInterval = (destinations, intervals, travelTime) => {
   const groups = {};
   intervals.forEach((interval) => {
     const points = destinations
-      .filter((point, index) => travelTime[index] <= interval * 60)
+      .filter((point, index) => (
+        travelTime[index] !== null && travelTime[index] <= interval * 60)
+      )
       .map(d => d.location);
 
     groups[interval] = points;


### PR DESCRIPTION
I have seen a few isochrones that look like this (Honolulu, Hawaii, USA):
![image](https://user-images.githubusercontent.com/1447967/28229807-37debe0e-68b2-11e7-9afd-0174aa82bbb6.png)

I discovered that some of the destination points that OSRM returns have a duration of `null`. This seems to be the response when there is no possible route.

Here the red points have `duration == null`, otherwise they are green (the gray points are the bounding box given that `radius = 50`):
![image](https://user-images.githubusercontent.com/1447967/28230195-f6e9941c-68b3-11e7-80bc-5ab7dbc531ef.png)

This is with my fix applied:
![image](https://user-images.githubusercontent.com/1447967/28230408-dc42a71a-68b4-11e7-9d8a-e1c243783ace.png)

![image](https://user-images.githubusercontent.com/1447967/28230384-bd601102-68b4-11e7-914b-c8ed151f8067.png)

Another case (Charlottetown, Prince Edward Island, Canada):

| Before | After |
| ------------- | ------------- |
|  ![image](https://user-images.githubusercontent.com/1447967/28230826-757e9fe6-68b6-11e7-8e90-f4bf132c6490.png) | ![image](https://user-images.githubusercontent.com/1447967/28230885-9c3d099c-68b6-11e7-96d3-f8e5f6bb9156.png) |