### PR TITLE
Add extra catch for empty polygons

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,13 +100,18 @@ const isochrone = (startPoint, options) =>
 
         const travelTime = table.durations[0] || [];
 
-        const pointsByInterval = groupByInterval(table.destinations, options.intervals, travelTime);
-        const polygons = makePolygons(pointsByInterval, options);
+        try {
+          const pointsByInterval = groupByInterval(table.destinations, options.intervals, travelTime);
+          const polygons = makePolygons(pointsByInterval, options);
 
-        const features = options.deintersect ? deintersect(polygons) : polygons;
-        const featureCollection = rewind(helpers.featureCollection(features));
+          const features = options.deintersect ? deintersect(polygons) : polygons;
+          const featureCollection = rewind(helpers.featureCollection(features));
 
-        resolve(featureCollection);
+          resolve(featureCollection);
+        }
+        catch (e) {
+          reject(e);
+        }
       });
     } catch (e) {
       reject(e);


### PR DESCRIPTION
Hi 

The whole process will die with `UnhanledException` if will request isochrone outside of the map
like `lng=0&lat=0` for Berlin

I'm not sure why it's not caught with the outer `try catch`, but this will solve the issue. 

Hope you'll review and merge. I'm having my k8s pods dying/restarting in production :)